### PR TITLE
recordsのバックエンド(テーブル、モデル、コントローラー)を設定

### DIFF
--- a/back/app/controllers/api/v1/records_controller.rb
+++ b/back/app/controllers/api/v1/records_controller.rb
@@ -1,0 +1,63 @@
+module Api
+  module V1
+    class RecordsController < ApplicationController
+      include ActionController::Cookies
+      include SessionsHelper
+      before_action :logged_in_user, only: %i[index show create destroy update]
+      before_action :correct_user, only: %i[show update destroy]
+
+      def index
+        @records = current_user.records  # ログインユーザーのレコードのみ取得する
+        render json: @records
+      end
+
+      def show
+        @record = Record.find(params[:id])
+        render json: @record
+      end
+
+      def create
+        @record = current_user.records.build(record_params)  # ログインユーザーに関連付けてレコードを作成
+        if @record.save
+          render json: @record, status: :created
+        else
+          render json: @record.errors, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        @record = Record.find(params[:id])
+        if @record.update(record_params)
+          render json: @record, status: :ok
+        else
+          render json: @record.errors, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @record = Record.find(params[:id])
+        @record.destroy
+        head :no_content
+      end
+
+      private
+
+      def record_params
+        params.require(:record).permit(:user_id, :project_id, :minutes, :date)
+      end
+
+      def logged_in_user
+        return if logged_in?
+
+        render json: { status: 'notLoggedIn', message: 'ログインしてください' }, status: :unauthorized
+      end
+
+      def correct_user
+        @record = current_user.records.find_by(id: params[:id])
+        return if @record
+
+        render json: { error: 'Unauthorized access' }, status: :unauthorized
+      end
+    end
+  end
+end

--- a/back/app/controllers/api/v1/records_controller.rb
+++ b/back/app/controllers/api/v1/records_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module V1
     class RecordsController < ApplicationController
@@ -7,7 +9,7 @@ module Api
       before_action :correct_user, only: %i[show update destroy]
 
       def index
-        @records = current_user.records  # ログインユーザーのレコードのみ取得する
+        @records = current_user.records # ログインユーザーのレコードのみ取得する
         render json: @records
       end
 
@@ -17,7 +19,7 @@ module Api
       end
 
       def create
-        @record = current_user.records.build(record_params)  # ログインユーザーに関連付けてレコードを作成
+        @record = current_user.records.build(record_params) # ログインユーザーに関連付けてレコードを作成
         if @record.save
           render json: @record, status: :created
         else

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -2,6 +2,11 @@
 
 class Project < ApplicationRecord
   belongs_to :user
+  has_many :records, dependent: :destroy
+
+  validates :name, presence: true
+  validates :company, presence: true
+  validates :work_type, presence: true
   validates :unit_price, numericality: { only_integer: true }
   validates :quantity, numericality: { only_integer: true }
   validates :is_completed, inclusion: { in: [true, false] }

--- a/back/app/models/record.rb
+++ b/back/app/models/record.rb
@@ -1,0 +1,8 @@
+class Record < ApplicationRecord
+  belongs_to :user
+  belongs_to :project
+  validates :user_id, presence: true, numericality: { only_integer: true }
+  validates :project_id, presence: true, numericality: { only_integer: true }
+  validates :minutes, presence: true, numericality: { only_integer: true }
+  validates :date, presence: true
+end

--- a/back/app/models/record.rb
+++ b/back/app/models/record.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class Record < ApplicationRecord
   belongs_to :user
   belongs_to :project
-  validates :user_id, presence: true, numericality: { only_integer: true }
-  validates :project_id, presence: true, numericality: { only_integer: true }
+  validates :user_id, numericality: { only_integer: true }
+  validates :project_id, numericality: { only_integer: true }
   validates :minutes, presence: true, numericality: { only_integer: true }
   validates :date, presence: true
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_many :records, dependent: :destroy
+  has_many :projects, dependent: :destroy
   has_many :posts, dependent: :destroy
 
   has_many :active_relationships, class_name: 'Relationship',

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       resources :password_resets,     only: %i[create edit update]
       resources :relationships,       only: %i[create destroy]
       resources :projects, only: %i[index show create update destroy]
+      resources :records
     end
   end
   get 'up' => 'rails/health#show', as: :rails_health_check

--- a/back/db/migrate/20240617172140_create_projects.rb
+++ b/back/db/migrate/20240617172140_create_projects.rb
@@ -3,7 +3,7 @@
 class CreateProjects < ActiveRecord::Migration[7.0]
   def change
     create_table :projects do |t|
-      t.integer :user_id
+      t.references :user, null: false, foreign_key: true
       t.string :company
       t.string :name
       t.string :work_type

--- a/back/db/migrate/20240618100839_create_records.rb
+++ b/back/db/migrate/20240618100839_create_records.rb
@@ -1,0 +1,13 @@
+class CreateRecords < ActiveRecord::Migration[6.1]
+  def change
+    create_table :records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :project, null: false, foreign_key: true
+      t.integer :minutes, null: false
+      t.datetime :date, null: false
+
+      t.timestamps
+    end
+  end
+end
+

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,82 +10,95 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_240_617_172_140) do
-  create_table 'active_storage_attachments', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'record_type', null: false
-    t.bigint 'record_id', null: false
-    t.bigint 'blob_id', null: false
-    t.datetime 'created_at', null: false
-    t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
-    t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness',
-                                                    unique: true
+ActiveRecord::Schema[7.0].define(version: 2024_06_18_100839) do
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table 'active_storage_blobs', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-    t.string 'key', null: false
-    t.string 'filename', null: false
-    t.string 'content_type'
-    t.text 'metadata'
-    t.string 'service_name', null: false
-    t.bigint 'byte_size', null: false
-    t.string 'checksum'
-    t.datetime 'created_at', null: false
-    t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table 'active_storage_variant_records', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci',
-                                                 force: :cascade do |t|
-    t.bigint 'blob_id', null: false
-    t.string 'variation_digest', null: false
-    t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table 'posts', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-    t.text 'content'
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'title'
-    t.index %w[user_id created_at], name: 'index_posts_on_user_id_and_created_at'
-    t.index ['user_id'], name: 'index_posts_on_user_id'
+  create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "content"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.index ["user_id", "created_at"], name: "index_posts_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table 'projects', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-    t.integer 'user_id'
-    t.string 'company'
-    t.string 'name'
-    t.string 'work_type'
-    t.integer 'unit_price'
-    t.integer 'quantity'
-    t.boolean 'is_completed'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "projects", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "company"
+    t.string "name"
+    t.string "work_type"
+    t.integer "unit_price"
+    t.integer "quantity"
+    t.boolean "is_completed"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_projects_on_user_id"
   end
 
-  create_table 'relationships', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-    t.integer 'follower_id'
-    t.integer 'followed_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['followed_id'], name: 'index_relationships_on_followed_id'
-    t.index %w[follower_id followed_id], name: 'index_relationships_on_follower_id_and_followed_id', unique: true
-    t.index ['follower_id'], name: 'index_relationships_on_follower_id'
+  create_table "records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "project_id", null: false
+    t.integer "minutes", null: false
+    t.datetime "date", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_records_on_project_id"
+    t.index ["user_id"], name: "index_records_on_user_id"
   end
 
-  create_table 'users', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-    t.string 'name'
-    t.string 'email', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'password_digest'
-    t.string 'work'
-    t.text 'profile_text'
-    t.string 'avatar'
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "relationships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
-  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'active_storage_variant_records', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'posts', 'users'
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.string "email", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "password_digest"
+    t.string "work"
+    t.text "profile_text"
+    t.string "avatar"
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "posts", "users"
+  add_foreign_key "projects", "users"
+  add_foreign_key "records", "projects"
+  add_foreign_key "records", "users"
 end

--- a/back/db/seeds.rb
+++ b/back/db/seeds.rb
@@ -1,40 +1,67 @@
 # frozen_string_literal: true
 
-# # # メインのサンプルユーザーを1人作成する
-# User.find_or_create_by(email: 'example@railstutorial.org') do |user|
-#     user.name = 'Example User'
-#     user.password = 'foobar'
-#     user.password_confirmation = 'foobar'
-#     user.admin = true
-#     user.activated = true
-#     user.activated_at = Time.zone.now
-#   end
+# usersテーブルのサンプルデータ作成
+# ユーザーの作成
+User.create(name: "さわた", email: "sawata@example.com", password: "foobar", password_confirmation: "foobar", work: "動画編集")
+User.create(name: "ゲスト", email: "guest@example.com", password: "foobar", password_confirmation: "foobar", work: "バックエンドエンジニア")
 
-#   # 追加のユーザーをまとめて生成する
-#   99.times do |n|
-#     name = Faker::Name.name
-#     email = "example-#{n + 1}@railstutorial.org"
-#     password = 'password'
-#     User.find_or_create_by(email:) do |user|
-#       user.name = name
-#       user.password = password
-#       user.password_confirmation = password
-#       user.activated = true
-#       user.activated_at = Time.zone.now
-#     end
-#   end
+# user1 から user10 を作成する
+user_count = 30
+work_types = ["YouTube専門動画編集者", "Shortsが得意な動画編集者", "NFT・Web3専門ライター", "Webライター", "ライター/動画編集者", "フロントエンドエンジニア(主にReact)", "バックエンドエンジニア(主にRails)"]
 
-#   # ユーザーの一部を対象にマイクロポストを生成する
-#   users = User.order(:created_at).take(6)
-#   50.times do
-#     content = Faker::Lorem.sentence(word_count: 5)
-#     users.each { |user| user.posts.create!(content:) }
-#   end
+(1..user_count).each do |i|
+  email = "user#{i}@example.com"
+  name = "user#{i}"
+  work = work_types[i % work_types.size]
+  
+  User.create(name: name, email: email, password: "foobar", password_confirmation: "foobar", work: work)
+end
 
-#   # ユーザーフォローのリレーションシップを作成する
-#   users = User.all
-#   user = users.first
-#   following = users[2..50]
-#   followers = users[3..40]
-#   following.each { |followed| user.follow(followed) unless user.following?(followed) }
-#   followers.each { |follower| follower.follow(user) unless follower.following?(user) }
+puts "ユーザーが作成されました。"
+
+# projectsテーブルのサンプルデータ作成
+unit_price_range = (1000..10000).to_a
+quantity_range = (2..30).to_a
+user_ids = (1..10).to_a
+companies = ["三和農業株式会社", "ネットワークエキスパーツ株式会社", "東日本電力株式会社", "テクノロジーイノベーターズ株式会社", "教育支援株式会社", "サポートスペシャリスツ株式会社", "都市開発株式会社", "第一不動産株式会社", "マーケティンググルーズ株式会社", "未来技術研究所"]
+project_names = ["ウェブ開発プロジェクト", "モバイルアプリデザイン", "ビジネスコンサルティング", "デジタルマーケティングキャンペーン", "ITサポートサービス", "クラウドインフラ構築", "データ分析プロジェクト"]
+work_types = ["開発", "デザイン", "コンサルティング", "マーケティング", "サポート"]
+
+user_ids.each do |user_id|
+  project_count = rand(7..21)  # 各ユーザーに対して7から21のプロジェクトをランダムに作成
+  project_count.times do |i|
+    created_at = rand(3.months.ago.to_f..Time.now.to_f).to_i
+    Project.create!(
+      user_id: user_id,
+      company: companies.sample,
+      name: project_names.sample,
+      work_type: work_types.sample,
+      unit_price: unit_price_range.sample,
+      quantity: quantity_range.sample,
+      is_completed: i < project_count / 2 ? false : true,  # 半分はfalse、半分はtrueに設定
+      created_at: Time.at(created_at)
+    )
+  end
+end
+
+puts "サンプルデータが作成されました。"
+
+# recrodsテーブルのサンプルデータ作成(userIdが1~10)
+(1..10).each do |user_id|
+    user = User.find(user_id)
+    projects = user.projects
+    
+    projects.each do |project|
+      record_count = rand(5..15)  # 各プロジェクトに対して5から15のレコードをランダムに作成
+      record_count.times do
+        Record.create!(
+          user_id: user_id,
+          project_id: project.id,
+          minutes: rand(30..120),  # ランダムに30から120の間で時間を設定
+          date: rand(3.months.ago..Time.now)  # ランダムに過去3ヶ月以内の日付を設定
+        )
+      end
+    end
+  end
+  
+  puts "サンプルデータが作成されました。"

--- a/back/spec/requests/records_spec.rb
+++ b/back/spec/requests/records_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # require 'rails_helper'
 
 # RSpec.describe "Records", type: :request do

--- a/back/spec/requests/records_spec.rb
+++ b/back/spec/requests/records_spec.rb
@@ -1,0 +1,7 @@
+# require 'rails_helper'
+
+# RSpec.describe "Records", type: :request do
+#   describe "GET /index" do
+#     pending "add some examples (or delete) #{__FILE__}"
+#   end
+# end

--- a/front/my-app/app/dashboard/components/GraphDailyEarnings.jsx
+++ b/front/my-app/app/dashboard/components/GraphDailyEarnings.jsx
@@ -47,7 +47,9 @@ const GraphDailyEarnings = () => {
         axios.get(`http://localhost:3000/api/v1/projects`, {
           withCredentials: true,
         }),
-        axios.get(`http://localhost:3001/records?user_id=${userId}`),
+        axios.get(`http://localhost:3000/api/v1/records`, {
+          withCredentials: true,
+        }),
       ]);
       const projects = projectsResponse.data || [];
       const records = recordsResponse.data || [];

--- a/front/my-app/app/dashboard/components/GraphHourlyRate.jsx
+++ b/front/my-app/app/dashboard/components/GraphHourlyRate.jsx
@@ -51,7 +51,9 @@ const GraphHourlyRate = () => {
         axios.get(`http://localhost:3000/api/v1/projects`, {
           withCredentials: true,
         }),
-        axios.get(`http://localhost:3001/records?user_id=${userId}`),
+        axios.get(`http://localhost:3000/api/v1/records`, {
+          withCredentials: true,
+        }),
       ]);
       const projects = projectsResponse.data || [];
       const records = recordsResponse.data || [];

--- a/front/my-app/app/dashboard/components/GraphWorkingMinutes.jsx
+++ b/front/my-app/app/dashboard/components/GraphWorkingMinutes.jsx
@@ -45,9 +45,9 @@ const GraphWorkingMinutes = () => {
 
   const fetchData = async (userId, month) => {
     try {
-      const response = await axios.get(
-        `http://localhost:3001/records?user_id=${userId}`
-      );
+      const response = await axios.get(`http://localhost:3000/api/v1/records`, {
+        withCredentials: true,
+      });
       const records = response.data || [];
       const minutesPerDay = {};
       const selectedMonthRecords = records.filter(

--- a/front/my-app/app/dashboard/components/MonthHWAT.jsx
+++ b/front/my-app/app/dashboard/components/MonthHWAT.jsx
@@ -10,7 +10,10 @@ const MonthHWAT = () => {
   const fetchData = async (userId) => {
     try {
       const recordsResponse = await axios.get(
-        `http://localhost:3001/records?user_id=${userId}`
+        `http://localhost:3000/api/v1/records`,
+        {
+          withCredentials: true, //クッキーを含める設定
+        }
       );
       const records = recordsResponse.data || [];
       console.log("Records:", records);

--- a/front/my-app/app/dashboard/components/ProjectHourlyWageRanking.jsx
+++ b/front/my-app/app/dashboard/components/ProjectHourlyWageRanking.jsx
@@ -8,10 +8,12 @@ const ProjectHourlyWageRanking = () => {
   const [error, setError] = useState(null);
   const [currentUser, setCurrentUser] = useState(null);
 
-  const fetchRankingData = async (userId) => {
+  const fetchRankingData = async () => {
     try {
       const [recordsResponse, projectsResponse] = await Promise.all([
-        axios.get(`http://localhost:3001/records?user_id=${userId}`),
+        axios.get(`http://localhost:3000/api/v1/records`, {
+          withCredentials: true,
+        }),
         axios.get(`http://localhost:3000/api/v1/projects`, {
           withCredentials: true,
         }),

--- a/front/my-app/app/dashboard/components/WorkTypeHourlyWageRanking.jsx
+++ b/front/my-app/app/dashboard/components/WorkTypeHourlyWageRanking.jsx
@@ -8,19 +8,17 @@ const WorkTypeHourlyWageRanking = () => {
   const [error, setError] = useState(null);
   const [currentUser, setCurrentUser] = useState(null);
 
-  const fetchRankingData = async (userId) => {
+  const fetchRankingData = async () => {
     try {
-      const [recordsResponse, projectsResponse] = await Promise.all([
-        axios.get(`http://localhost:3001/records?user_id=${userId}`),
-        axios.get(`http://localhost:3000/api/v1/projects`, {
-          withCredentials: true,
-        }),
-      ]);
+      const { data: records } = await axios.get(
+        `http://localhost:3000/api/v1/records`,
+        { withCredentials: true }
+      );
+      const { data: projects } = await axios.get(
+        `http://localhost:3000/api/v1/projects`,
+        { withCredentials: true }
+      );
 
-      const records = recordsResponse.data || [];
-      const projects = projectsResponse.data || [];
-
-      // work_typeごとの時給平均を計算
       const workTypeHourlyWages = {};
 
       records.forEach((record) => {
@@ -45,7 +43,7 @@ const WorkTypeHourlyWageRanking = () => {
             workTypeHourlyWages[work_type].totalUnitPriceTimesQuantity /
             (workTypeHourlyWages[work_type].totalMinutes / 60),
         }))
-        .sort((a, b) => b.averageHourlyWage - a.averageHourlyWage); // 高い順にソート
+        .sort((a, b) => b.averageHourlyWage - a.averageHourlyWage);
 
       setRanking(ranking);
     } catch (error) {


### PR DESCRIPTION
## やったこと

* このプルリクで何をしたのか？
recordsテーブルの作成、モデルバリデーションの設定、コントローラーの設定。
コントローラーでは/rocordsで取得できるデータを現在ログイン中のユーザーのみに設定。

## できるようになること（ユーザ目線）
* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）
* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
db.jsonでrecrodのデータを記入してデータを変更すること

## その他
* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載
リファクタリングはまだまだできそうです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プロジェクトモデルに `name`, `company`, `work_type` フィールドのバリデーションを追加。
  - レコードモデルに `user_id`, `project_id`, `minutes`, `date` フィールドのバリデーションとユーザー、プロジェクトとのアソシエーションを追加。
  - ユーザーモデルに `records`, `projects` アソシエーションを追加。
  - `projects` の下に `records` リソースルートを追加。
  - 新しい `records` テーブルを作成するマイグレーションを追加。

- **修正**
  - 過去の一部の API エンドポイントを新しいエンドポイントに更新。
  - `GraphDailyEarnings`, `GraphHourlyRate`, `GraphWorkingMinutes`, `MonthHWAT`, `ProjectHourlyWageRanking`, `WorkTypeHourlyWageRanking` コンポーネントの Axios リクエストを修正。

- **データシード**
  - `seeds.rb` でのユーザー、プロジェクト、レコードのサンプルデータ作成ロジックを更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->